### PR TITLE
fix: add basic support for nested lists

### DIFF
--- a/src/asciidoc.ts
+++ b/src/asciidoc.ts
@@ -53,12 +53,33 @@ export const AsciiDoc = {
   /** @returns a list, followed by an empty line */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   list(body: string, _ordered: boolean): string {
-    return `${body}\n`;
+    return `\n${body}\n`;
   },
 
-  /** @returns a list item prefixed with '*' */
+  /**
+   * Updates the listitem (including sub items) to use the correct prefix ('*')
+   * and adds a '+' to the start of each empty line to support paragraphs
+   *
+   * @returns a list item prefixed with '*'
+   */
   listitem(text: string): string {
-    return `* ${text.trimEnd().replace(/^\r?\n/gm, "+\n")}\n`;
+    let result = text;
+    let offset = 0;
+
+    // Increases the depth of the list items by one
+    for (const item of text.matchAll(/^\*+\s+/gm)) {
+      if (item.index === undefined) continue;
+      result = result.slice(0, item.index + offset) + "*" + result.slice(item.index + offset);
+      offset += 1;
+    }
+
+    // Converts paragraph to bullet point
+    result = `* ${result.trimEnd().replace(/^\r?\n/gm, "+\n")}\n`;
+
+    // Replaces multiple '+' with a single '+'
+    result = result.replace(/(\+\n){2,}/gm, "+\n");
+
+    return result;
   },
 
   /** @returns a checkbox */

--- a/test/asciidoc.test.ts
+++ b/test/asciidoc.test.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import { AsciiDoc } from "../src";
 
 describe("Render", () => {
-  test("Render markdown", () => {
+  test("Render Asciidoc", () => {
     const data = fs.readFileSync(path.join(__dirname, "fixtures", "full-usecase.md"), "utf-8");
     const expected = fs.readFileSync(path.join(__dirname, "fixtures", "full-usecase.md.asciidoc"), "utf-8");
 

--- a/test/fixtures/full-usecase.md
+++ b/test/fixtures/full-usecase.md
@@ -16,10 +16,19 @@ lines
 </div>
 
 ## Lists
+This chapter contains lists:
+* List item 1.1
+  * Item 1.1.1
+    * Item 1.1.1.1
 
-* List item 1
-* List item 2
-* List item 3
+      We can add more details
+    * Item 1.1.1.2
+
+      And here
+
+      Which is providing multiple empty lines
+* List item 1.2
+* List item 1.3
   which is a list spanning multiple lines and paragraphs.
 
   And includes block items;
@@ -29,6 +38,17 @@ lines
     return stair.split("CENTER") as Stair[];
   }
   ```
+* List item 1.4
+  
+  This one contains lists in lists
+
+  * Item A
+  * Item B
+
+  Which is seperated from
+
+  * Item C
+  * Item D
 
 ## Formatting
 

--- a/test/fixtures/full-usecase.md.asciidoc
+++ b/test/fixtures/full-usecase.md.asciidoc
@@ -18,9 +18,22 @@ lines
 ++++
 
 == Lists
-* List item 1
-* List item 2
-* List item 3
+This chapter contains lists:
+
+
+* List item 1.1
++
+** Item 1.1.1
+*** Item 1.1.1.1
++
+We can add more details
+*** Item 1.1.1.2
++
+And here
++
+Which is providing multiple empty lines
+* List item 1.2
+* List item 1.3
 which is a list spanning multiple lines and paragraphs.
 +
 And includes block items;
@@ -31,8 +44,20 @@ function doit(stair: Stair): Stair[] {
   return stair.split("CENTER") as Stair[];
 }
 ----
+* List item 1.4
++
+This one contains lists in lists
++
+** Item A
+** Item B
++
+Which is seperated from
++
+** Item C
+** Item D
 
 == Formatting
+
 * This **word** uses bold formatting
 * This __word__ uses italic formatting
 * This [.line-through]#word# uses strikethrough formatting
@@ -46,11 +71,13 @@ spanning multiple lines
 ----
 
 == Inline refs
+
 * This line contains http://does-not-exist[a link with description]
 * This line contains a link without description: http://does-not-exist
 * This line embeds an image with alt text: image:path-to-image.png[image]
 
 == Checkboxes
+
 * [ ] This is unchecked
 * [x] This is checked
 


### PR DESCRIPTION
This commit introduces basic support for nested markdown lists. There are two particular caveats:

- A newline between the list item and paragraph is needed to replicate the same style of rendering
- Paragraphs might not be rendered on the right depth of nested lists